### PR TITLE
HAProxy and uStreamer config improvements

### DIFF
--- a/haproxy1x.basic
+++ b/haproxy1x.basic
@@ -1,9 +1,9 @@
 global
-        maxconn 4096
+        maxconn 1024
         user haproxy
         group haproxy
         daemon
-        log 127.0.0.1 local0 debug
+        log 127.0.0.1 local0 warning
 
 defaults
         log     global

--- a/haproxy2x.basic
+++ b/haproxy2x.basic
@@ -2,11 +2,11 @@
 #https://community.octoprint.org/t/setting-up-octoprint-on-a-computer-running-fedora-centos-almalinux-or-rockylinux/37137/2
 
 global
-        maxconn 4000
+        maxconn 1024
         user haproxy
         group haproxy
         daemon
-        log 127.0.0.1 local0 debug
+        log 127.0.0.1 local0 warning
 
 defaults
         log     global

--- a/octocam_ustream.service
+++ b/octocam_ustream.service
@@ -5,7 +5,7 @@ Wants=network.online.target
 
 [Service]
 User=OCTOUSER
-ExecStart=/home/OCTOUSER/ustreamer/ustreamer -d /dev/OCTOCAM -s 0.0.0.0 -m MJPEG -r RESOLUTION -f FRAMERATE -p CAMPORT --device-timeout 8 --device-error-delay 8
+ExecStart=/home/OCTOUSER/ustreamer/ustreamer -d /dev/OCTOCAM -s 0.0.0.0 -m MJPEG -r RESOLUTION -f FRAMERATE -p CAMPORT --device-timeout 8 --device-error-delay 8 --slowdown
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Reduce HAProxy logging level from debug to warning (reduces potential IO and CPU).
- Set HAProxy to a more reasonable max connections (1024 is still a lot, but 4096 seemed excessive).
- Add `--slowdown` to ustreamer to reduce CPU load when the camera stream is not active.