### PR TITLE
Fortify installation of µStreamer

### DIFF
--- a/octoprint_install.sh
+++ b/octoprint_install.sh
@@ -40,12 +40,14 @@ prompt_confirm() {
     done
 }
 
+
 get_settings() {
     #Get octoprint_deploy settings, all of which are written on system prepare
-    if [ -f /etc/octoprint_deploy ]; then
-        TYPE=$(cat /etc/octoprint_deploy | sed -n -e 's/^type: \(\.*\)/\1/p')
-        STREAMER=$(cat /etc/octoprint_deploy | sed -n -e 's/^streamer: \(\.*\)/\1/p')
-        HAPROXY=$(cat /etc/octoprint_deploy | sed -n -e 's/^haproxy: \(\.*\)/\1/p')
+    OCTODEPLOY="/etc/octoprint_deploy"
+    if [ -f $OCTODEPLOY ]; then
+        TYPE=$(cat $OCTODEPLOY | sed -n -e 's/^type: \(\.*\)/\1/p')
+        STREAMER=$(cat $OCTODEPLOY | sed -n -e 's/^streamer: \(\.*\)/\1/p')
+        HAPROXY=$(cat $OCTODEPLOY | sed -n -e 's/^haproxy: \(\.*\)/\1/p')
     fi
     OCTOEXEC="sudo -u $user /home/$user/OctoPrint/bin/octoprint"
     OCTOCONFIG="/home/$user"
@@ -89,6 +91,8 @@ deb_packages() {
 }
 
 prepare() {
+    get_settings
+
     echo
     echo
     PS3='OS type: '
@@ -186,7 +190,7 @@ prepare() {
             if prompt_confirm "Use haproxy?"; then
                 systemctl stop haproxy
                 #get haproxy version
-                echo 'haproxy: true' >>/etc/octoprint_deploy
+                echo 'haproxy: true' >>$OCTODEPLOY
                 HAversion=$(haproxy -v | sed -n 's/^.*version \([0-9]\).*/\1/p')
                 mv /etc/haproxy/haproxy.cfg /etc/haproxy/haproxy.orig
                 if [ $HAversion -gt 1 ]; then
@@ -255,6 +259,8 @@ prepare() {
 }
 
 streamer_install() {
+    get_settings
+
     PS3='Which video streamer you would like to install?: '
     options=("mjpeg-streamer" "ustreamer (recommended)" "None")
 
@@ -293,7 +299,7 @@ streamer_install() {
 
         if [ -f "/home/$user/mjpg-streamer/mjpg_streamer" ]; then
             echo "mjpg_streamer installed successfully"
-            echo 'streamer: mjpg-streamer' >> /etc/octoprint_deploy
+            echo 'streamer: mjpg-streamer' >> $OCTODEPLOY
         else
             echo "There was a problem installing the streamer. Please try again."
             streamer_install
@@ -308,7 +314,7 @@ streamer_install() {
 
         if [ -f "/home/$user/ustreamer/ustreamer" ]; then
             echo "ustreamer installed successfully"
-            echo 'streamer: ustreamer' >> /etc/octoprint_deploy
+            echo 'streamer: ustreamer' >> $OCTODEPLOY
         else
             echo "There was a problem installing the streamer. Please try again."
             streamer_install
@@ -607,8 +613,8 @@ add_camera() {
 
 remove_everything() {
     get_settings
-    if [ -f "/etc/octoprint_deploy" ]; then
-        rm -f /etc/octoprint_deploy
+    if [ -f $OCTODEPLOY ]; then
+        rm -f $OCTODEPLOY
     fi
     if [ -d "/home/$user/mjpg-streamer" ]; then
         rm -rf /home/$user/mjpg-streamer
@@ -641,6 +647,8 @@ remove_everything() {
 }
 
 main_menu() {
+    get_settings
+
     VERSION=0.2.0
     CAM=''
     TEMPUSBCAM=''
@@ -651,7 +659,7 @@ main_menu() {
     echo "*************************"
     echo
     PS3='Select operation: '
-    if [ -f "/etc/octoprint_deploy" ]; then
+    if [ -f $OCTODEPLOY ]; then
         options=("Add USB Camera" "Quit")
     else
         options=("Install OctoPrint" "Quit")

--- a/octoprint_install.sh
+++ b/octoprint_install.sh
@@ -165,11 +165,11 @@ prepare() {
             #make venv
             sudo -u $user $PYVERSION -m venv $OCTOCONFIG/OctoPrint
             #update pip
-            sudo -u $user $OCTOCONFIG/OctoPrint/bin/pip install --upgrade pip
+            $OCTOPIP install --upgrade pip
             #pre-install wheel
-            sudo -u $user $OCTOCONFIG/OctoPrint/bin/pip install wheel
+            $OCTOPIP install wheel
             #install oprint
-            sudo -u $user $OCTOCONFIG/OctoPrint/bin/pip install OctoPrint
+            $OCTOPIP install OctoPrint
             #start server and run in background
             echo 'Creating OctoPrint service...'
             cat $SCRIPTDIR/octoprint_generic.service |

--- a/octoprint_install.sh
+++ b/octoprint_install.sh
@@ -313,10 +313,13 @@ streamer_install() {
     if [ $VID -eq $USTREAMER_SELECTED ]; then
         
         #install ustreamer
-        sudo -u $user git clone --depth=1 https://github.com/pikvm/ustreamer
-        sudo -u $user make --directory=ustreamer > /dev/null
+        USTREAMER_INSTALLATION="$OCTOCONFIG/ustreamer"
 
-        if [ -f "$OCTOCONFIG/ustreamer/ustreamer" ]; then
+        sudo -u $user git clone --depth=1 https://github.com/pikvm/ustreamer $USTREAMER_INSTALLATION
+        echo "Compiling ustreamer ..."
+        sudo -u $user make --directory=$USTREAMER_INSTALLATION > /dev/null
+
+        if [ -f "$USTREAMER_INSTALLATION/ustreamer" ]; then
             echo "ustreamer installed successfully"
             echo 'streamer: ustreamer' >> $OCTODEPLOY
         else

--- a/octoprint_install.sh
+++ b/octoprint_install.sh
@@ -257,26 +257,31 @@ prepare() {
 streamer_install() {
     PS3='Which video streamer you would like to install?: '
     options=("mjpeg-streamer" "ustreamer (recommended)" "None")
+
+    MJPEGSTREAMER_SELECTED=1
+    USTREAMER_SELECTED=2
+    OPT_OUT_SELECTED=3
+
     select opt in "${options[@]}"
     do
         case $opt in
             "mjpeg-streamer")
-                VID=1
+                VID=$MJPEGSTREAMER_SELECTED
                 break
             ;;
             "ustreamer (recommended)")
-                VID=2
+                VID=$USTREAMER_SELECTED
                 break
             ;;
             "None")
-                VID=3
+                VID=$OPT_OUT_SELECTED
                 break
             ;;
             *) echo "invalid option $REPLY";;
         esac
     done
     
-    if [ $VID -eq 1 ]; then
+    if [ $VID -eq $MJPEGSTREAMER_SELECTED ]; then
         
         #install mjpg-streamer, not doing any error checking or anything
         echo 'Installing mjpeg-streamer'
@@ -295,11 +300,11 @@ streamer_install() {
         fi
     fi
     
-    if [ $VID -eq 2 ]; then
+    if [ $VID -eq $USTREAMER_SELECTED ]; then
         
         #install ustreamer
         sudo -u $user git clone --depth=1 https://github.com/pikvm/ustreamer
-        sudo -u $user make -C ustreamer > /dev/null
+        sudo -u $user make --directory=ustreamer > /dev/null
 
         if [ -f "/home/$user/ustreamer/ustreamer" ]; then
             echo "ustreamer installed successfully"
@@ -310,7 +315,7 @@ streamer_install() {
         fi
     fi
     
-    if [ $VID -eq 3 ]; then
+    if [ $VID -eq $OPT_OUT_SELECTED ]; then
         echo "Good for you! Cameras are just annoying anyway."
     fi
 }

--- a/octoprint_install.sh
+++ b/octoprint_install.sh
@@ -261,7 +261,12 @@ streamer_install() {
     get_settings
 
     PS3='Which video streamer you would like to install?: '
-    options=("mjpeg-streamer" "ustreamer (recommended)" "None")
+
+    MJPEGSTREAMER_OPTION="mjpeg-streamer"
+    USTREAMER_OPTION="ustreamer (recommended)"
+    OPT_OUT_OPTION="None"
+
+    options=("$MJPEGSTREAMER_OPTION" "$USTREAMER_OPTION" "$OPT_OUT_OPTION")
 
     MJPEGSTREAMER_SELECTED=1
     USTREAMER_SELECTED=2
@@ -270,15 +275,15 @@ streamer_install() {
     select opt in "${options[@]}"
     do
         case $opt in
-            "mjpeg-streamer")
+            $MJPEGSTREAMER_OPTION)
                 VID=$MJPEGSTREAMER_SELECTED
                 break
             ;;
-            "ustreamer (recommended)")
+            $USTREAMER_OPTION)
                 VID=$USTREAMER_SELECTED
                 break
             ;;
-            "None")
+            $OPT_OUT_OPTION)
                 VID=$OPT_OUT_SELECTED
                 break
             ;;


### PR DESCRIPTION
I encountered some installation problems while following the steps below, and made some changes to the installation script to avoid these problems.

Steps that lead to problems:

1. Become root: `sudo su`
2. Clone to `/tmp/` directory: `git clone https://github.com/paukstelis/octoprint_install.git /tmp/octoprint_install`
3. Return to non-root user: `exit`
4. Navigate into cloned directory: `cd /tmp/octoprint_install`
5. Trigger `octoprint_install.sh` execution: `sudo ./octoprint_install.sh`
6. Follow prompts until asked about ustreamer installation
7. Select `ustreamer`

Expected behavior: ustreamer is installed
Actual behavior: `fatal: could not create work tree dir 'ustreamer': Permission denied`
Fix: Download `ustreamer` explicitly into user's home directory.

System specs:

* Platform: Orange Pi 3 LTS
* Operating System: Orangepi3-lts_3.0.8_debian_bullseye_server_linux5.16.17.img
